### PR TITLE
chore: add project information docs

### DIFF
--- a/integrations/adding-your-project/README.md
+++ b/integrations/adding-your-project/README.md
@@ -1,16 +1,6 @@
 # Adding Your Project
 
-@zak
-
-
-
-### Step 1
-
 {% page-ref page="protocol-information.md" %}
-
-### Step 2
-
-{% page-ref page="treasury-information.md" %}
 
 {% hint style="info" %}
 Questions? Join our Discord and post in the Boardroom Support Channel - [\#❓support](https://discord.gg/CEZ8WfuK8s)

--- a/integrations/adding-your-project/protocol-information.md
+++ b/integrations/adding-your-project/protocol-information.md
@@ -1,14 +1,103 @@
-# Protocol Information
+# Project Information
 
-### The Project Information Repository 
+All project addition and edits occur on the public [Project Information repository on Github](https://github.com/boardroom-inc/protocol-Info), where all information seen in the Boardroom governance portal is uploaded, stored, and maintained. These docs will walk you through how to add the necessary project information to this repository in a few simple steps, to get your project added to the Boardroom Portal frontend.
 
-All project addition and edits occur on the public [Project Information repository on Github](https://github.com/boardroom-inc/protocol-Info), where all information seen in the Boardroom governance portal is uploaded, stored, and maintained. These docs will walk you through how to add the necessary project information to this repository in a few simple steps, to get your project added to the Boardroom Portal frontend. 
+## Add a new project
 
-If you're a person or team that wants to add a project to Boardroom and/or update information for an existing project, you can do so by: 
+Fork the [protocol-info repo](https://github.com/boardroom-inc/protocol-Info) to your GitHub account, then clone your forked repo:
 
-1. Creating a new branch
-2. Making and committing changes
-3. Submitting a pull request
+```sh
+$ git@github.com:your-github-account/protocol-Info.git
+```
 
-The Boardroom team will then review your pull request and merge if... \(INSERT\) 
+Create a working branch:
 
+```sh
+$ git checkout -b your-project-name
+```
+
+Copy the `protocols/__example` folder to a new folder under `protocols`:
+
+```sh
+$ cp -r protocols/__example protocols/your-project-name
+```
+
+## Update project
+
+Within your new protocol folder, update the info and assets for your project.
+
+### Project metadata
+
+Update the `index.json` file to define your project metadata.
+
+| Property                    | Type                         | Description                                              |
+|  ---------------------------|------------------------------|----------------------------------------------------------|
+| `cname`                     | `string`                      | A unique identifier for the project.                    |
+| `name`                      | `string`                      | The human-readable name of the protocol.                |
+| `description`               | `string`                      | A short blurb about the protocol.                       |
+| `path`                      | `string`                      | The Boardroom portal slug for the protocol.             |
+| `type`                      | `"snapshot" \| "compoundish"` | The governance type of the protocol.                    |
+| `suffix`                    | `string`                      | The token ticker for the protocol.                      |
+| `coinGeckoPriceString`      | `string`                      | The CoinGecko token slug for the protocol.              |
+| `tokenContractAddress`      | `string`                      | The Ethereum address of the token contract.             |
+| `governanceContractAddress` | `string`                      | The Ethereum address of the governance contract.        |
+| `isEnabled`                 | `boolean`                     | A flag defining whether or not the protocol is enabled. |
+| `hasOnchain`                | `boolean`                     | A flag defining whether or not the protocol is on-chain. |
+| `isHybrid`                  | `boolean`                     | A flag defining whether or not the protocol uses hybrid governance. |
+| `hasDelegation`             | `boolean`                     | A flag defining whether or not the protocol supports delegation. |
+| `snapshotSpaceName`         | `string`                      | The Snapshot hub slug for the protocol.                 |
+| `invalidSnapshots`          | `string[]`                    | A list of snapshot proposals to be hidden from the `hub-ui` proposal list.                 |
+| `discourseForum.url`        | `string`                      | The URL to the protocol Discourse forum.                 |
+| `discourseForum.categoryId` | `string`                      | The category ID of the protocol Discourse forum to be sourced.         |
+| `safeAddress`               | `string`                      | The Ethereum address to the project's Parcel safe.       |
+
+### Overview
+
+Update the `overview.md` file with a high-level description of your project and its governance process (see [Index](https://github.com/boardroom-inc/protocol-Info/blob/main/protocols/indexCoop/overview.md) for an example).
+
+### Contracts
+
+Add your token and governance contract (if applicable) ABIs to the `contracts` folder in the corresponding `token.json` and `governance.json` files.
+
+### Logos
+
+1. Replace **header.png** with your full logo
+1. Replace **logo.png** with your icon logo
+
+### Resources
+
+Add markdown files to the `resources` folder -- these can be weekly governance call notes, development and product updates, etc. Categorize these resources into subfolders (see [Index](https://github.com/boardroom-inc/protocol-Info/tree/main/protocols/indexCoop/resources) for an example).
+
+### Events
+
+1. Add one or more new events to the `events.json` file of the protocol using the following format:
+
+- **title**: The title of the event - this will be shown in the month and day view.
+- **url**: A URL to link to when an event is clicked.
+- **date**: The UTC date of the event in ISO 8601 format
+
+```json
+[
+  {
+    "title": "This is an example event.",
+    "url": "https://example.com",
+    "date": "2021-01-08T00:00:00.000Z"
+  },
+  {
+    "title": "This is another example event.",
+    "url": "https://example.com",
+    "date": "2021-01-10T00:00:00.000Z"
+  }
+]
+```
+
+## Open pull request
+
+Commit your changes and push your branch to your remote repository:
+
+```sh
+$ git commit -am "add your protocol name"
+$ git push origin your-project-name
+```
+
+Submit a pull request to the [protocol-info repo](https://github.com/boardroom-inc/protocol-Info). The Boardroom team will then review and merge your pull request after verifying the changes.

--- a/integrations/adding-your-project/treasury-information.md
+++ b/integrations/adding-your-project/treasury-information.md
@@ -1,4 +1,0 @@
-# Treasury Information
-
-\[Parcel\]
-


### PR DESCRIPTION
This PR adds a guide for adding and maintaining project information within the [protocol-info repo](https://github.com/boardroom-inc/protocol-Info).